### PR TITLE
Fix REST API scenario schema corruption blocking non-overlay_image action writes

### DIFF
--- a/composite-products-conditional-images-for-woocommerce.php
+++ b/composite-products-conditional-images-for-woocommerce.php
@@ -3,7 +3,7 @@
 * Plugin Name: Composite Products - Conditional Images
 * Plugin URI: https://docs.woocommerce.com/document/composite-products/composite-products-extensions/#cp-ci
 * Description: Free mini-extension for WooCommerce Composite Products that allows you to create dynamic, multi-layer Composite Product images that respond to option changes.
-* Version: 2.0.2
+* Version: 2.0.3
 * Author: WooCommerce
 * Author URI: https://woocommerce.com/
 *
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main plugin class.
  *
  * @class    WC_CP_Conditional_Images
- * @version  2.0.2
+ * @version  2.0.3
  */
 class WC_CP_Conditional_Images {
 
@@ -39,7 +39,7 @@ class WC_CP_Conditional_Images {
 	 *
 	 * @var string
 	 */
-	public static $version = '2.0.2';
+	public static $version = '2.0.3';
 
 	/**
 	 * Min required CP version.
@@ -113,9 +113,6 @@ class WC_CP_Conditional_Images {
 
 		// Add qty data in scenarios.
 		add_filter( 'woocommerce_composite_current_scenario_data', array( __CLASS__, 'scenario_data' ), 10, 4 );
-
-		// Allow 'overlay_image' scenario actions to be created via the REST API.
-		add_filter( 'woocommerce_rest_api_extended_composite_scenarios_field_args', array( __CLASS__, 'add_rest_api_scenario_action' ) );
 	}
 
 	/**
@@ -360,17 +357,6 @@ class WC_CP_Conditional_Images {
 			</div>
 			<?php
 		}
-	}
-
-	/**
-	 * Add support for creating 'overlay_image' scenario actions via the REST API.
-	 *
-	 * @since  1.1.1
-	 * @param  array
-	 */
-	public static function add_rest_api_scenario_action( $args ) {
-		$args[ 'schema' ][ 'items' ][ 'properties' ][ 'actions' ][ 'items' ][ 'properties' ][ 'action_id' ][ 'enum' ][] = 'overlay_image';
-		return $args;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, composite, conditional, image, layers, overlay
 Requires at least: 6.2
 Tested up to: 6.6
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 Requires PHP: 7.4
 WC requires at least: 8.2
 WC tested up to: 9.1
@@ -82,6 +82,9 @@ Composite Products - Conditional Images:
 
 
 == Changelog ==
+
+= 2.0.3 =
+* Fix - Removed an obsolete REST API scenario schema modification that corrupted the Composite Products scenario actions schema, causing the Products endpoint to reject writes for all scenario action types other than 'overlay_image'.
 
 = 2.0.2 =
 * Fix - Fixed script dependencies when using block themes.


### PR DESCRIPTION
## What?
Removes an obsolete REST API schema modification that corrupted the Composite Products scenario actions schema, causing the `wc/v3` Products endpoint to reject writes for every scenario action type other than `overlay_image` (`compat_group`, `conditional_components`, `conditional_options`). A plain GET → PUT round-trip of a product's own scenario data failed with a 400.

Closes [STRPROD-910: Conditional Images 2.0.2: REST API schema corruption blocks all non-overlay_image scenario action writes](https://linear.app/a8c/issue/STRPROD-910/conditional-images-202-rest-api-schema-corruption-blocks-all-non)

## How?

- The `add_rest_api_scenario_action()` filter appended `overlay_image` to `schema.items.properties.actions.items.properties.action_id.enum`. That path only existed under the pre-CP-8.0 flat schema.
- CP 8.0.0 (PR #640, Mar 2021) replaced it with a `oneOf` structure, so `properties.action_id` no longer exists and PHP auto-vivified a corrupted single-element `enum: ['overlay_image']` alongside the valid `oneOf` branches.
- WordPress validates **both** the `oneOf` and the sibling `properties`, so every action write whose `action_id` wasn't `overlay_image` failed with `rest_not_in_enum` / 400.
- CP already accepts `overlay_image` natively through its generic `action_data` catch-all `oneOf` branch (present since 8.0.0), which round-trips symmetrically with the read path. The schema modification is therefore obsolete for every supported CP version (the plugin requires CP ≥ 10.0) and was the sole cause of the corruption — so it's removed entirely rather than rewritten.
- Bumped version to 2.0.3 and added a changelog entry.

No change to the minimum CP version: the catch-all path predates the existing 10.0 floor by two majors, so nothing newer is required.

## Testing Instructions
1. On a site with WooCommerce, Composite Products 11.x, and this branch active, create a Composite Product with two components and a Scenario using a **Conditional Components** action (note the product ID and a component ID).
2. Create a read/write REST API key (**WooCommerce → Settings → Advanced → REST API**).
3. GET the product and confirm the API returns the action:
   `curl -su "ck:cs" "https://<site>/wp-json/wc/v3/products/<id>"` → `composite_scenarios[].actions[].action_id` includes `conditional_components`.
4. PUT the scenario back using the exact shape returned by GET:
   ```
   curl -su "ck:cs" -X PUT "https://<site>/wp-json/wc/v3/products/<id>" \
     -H "Content-Type: application/json" \
     -d '{"composite_scenarios":[{"name":"Test","enabled":true,"actions":[{"action_id":"conditional_components","is_active":true,"hidden_components":["<component_id>"]}]}]}'
   ```
5. Expect **200 OK** and the scenario persisted (before this fix: `400 rest_invalid_param` — "action_id is not overlay_image").
6. Regression check — confirm an `overlay_image` action still round-trips: PUT `{"action_id":"overlay_image","is_active":true,"action_data":{"image_id":<id>}}` and verify it returns 200 and the overlay still renders on the product page.