### PR TITLE
Bump tested-up-to to WordPress 7.0 and WooCommerce 10.8

### DIFF
--- a/composite-products-conditional-images-for-woocommerce.php
+++ b/composite-products-conditional-images-for-woocommerce.php
@@ -11,10 +11,10 @@
 * Domain Path: /languages/
 *
 * Requires at least: 6.2
-* Tested up to: 6.6
+* Tested up to: 7.0
 *
 * WC requires at least: 8.2
-* WC tested up to: 9.1
+* WC tested up to: 10.8
 *
 * Copyright: © 2017-2024 WooCommerce.
 * License: GNU General Public License v3.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,11 +3,11 @@
 Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, composite, conditional, image, layers, overlay
 Requires at least: 6.2
-Tested up to: 6.6
+Tested up to: 7.0
 Stable tag: 2.0.2
 Requires PHP: 7.4
 WC requires at least: 8.2
-WC tested up to: 9.1
+WC tested up to: 10.8
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## What?
Updates the plugin's compatibility metadata to reflect the current WordPress and WooCommerce versions.

- WordPress **Tested up to**: 6.6 → **7.0**
- WooCommerce **WC tested up to**: 9.1 → **10.8**

Applied in both the plugin header and `readme.txt`.

## How?
- Pure metadata change — no functional code touched.
- Deliberately leaves the version number and changelog alone so this stays independent of #20 (the REST schema fix) and the two branches don't conflict. The version bump + changelog can be folded in at release time.

## Testing Instructions
1. Check the plugin header in `composite-products-conditional-images-for-woocommerce.php` and the `readme.txt` header.
2. Expect `Tested up to: 7.0` and `WC tested up to: 10.8`.
3. No runtime behaviour to verify.