### PR TITLE
chore: bump WC tested-up-to to 10.9

### DIFF
--- a/composite-products-conditional-images-for-woocommerce.php
+++ b/composite-products-conditional-images-for-woocommerce.php
@@ -14,7 +14,7 @@
 * Tested up to: 7.0
 *
 * WC requires at least: 8.2
-* WC tested up to: 10.8
+* WC tested up to: 10.9
 *
 * Copyright: © 2017-2024 WooCommerce.
 * License: GNU General Public License v3.0

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 7.0
 Stable tag: 2.0.3
 Requires PHP: 7.4
 WC requires at least: 8.2
-WC tested up to: 10.8
+WC tested up to: 10.9
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## What?
- Updates the WooCommerce compatibility metadata to declare support for WooCommerce 10.9. No functional change.

## How?
- Bumped `WC tested up to` from 10.8 to 10.9 in the plugin header (`composite-products-conditional-images-for-woocommerce.php`)
- Bumped the matching `WC tested up to` line in `readme.txt`

## Testing Instructions
No manual testing needed — metadata-only change. Confirm both files read `10.9` and the plugin still activates cleanly.